### PR TITLE
Updated settings.py to support latest Django 1.4.2

### DIFF
--- a/sample/settings.py
+++ b/sample/settings.py
@@ -79,7 +79,7 @@ TEMPLATE_LOADERS = (
 )
 TEMPLATE_CONTEXT_PROCESSORS = (
     # default template context processors
-    'django.core.context_processors.auth',
+    'django.contrib.auth.context_processors.auth',
     'django.core.context_processors.debug',
     'django.core.context_processors.i18n',
     'django.core.context_processors.media',


### PR DESCRIPTION
Django in 1.4 uses

```
'django.contrib.auth.context_processors.auth',
```

now, with the old auth it will not work at all.

I was given this error: http://i.imgur.com/Mk6fj.png

With this patch everything is up and running for 1.4.2
