### PR TITLE
password reset info text fix

### DIFF
--- a/templates/registration/password_reset_form.html
+++ b/templates/registration/password_reset_form.html
@@ -13,7 +13,7 @@
                 <legend><span class="col-sm-offset-1">{% trans "Password reset" %}</span></legend>
                 <div class="form-group">
                     <div class="col-sm-offset-2 col-sm-10 text-info">
-                        {% trans "Please enter your old password, for security's sake, and then enter your new password twice so we can verify you typed it in correctly." %}
+                        {% trans "Please enter your email address." %}
                     </div>
                 </div>
                 {% for field in form %}


### PR DESCRIPTION
Hi!

Password reset form has only an email field (by default), I suppose this is a copy-paste issue.
