### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/ebertti/django-registration-bootstrap/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
 
-##Simple sample using bootstrap from twitter in forms of Django
+## Simple sample using bootstrap from twitter in forms of Django
 
 Using Bootstrap from Twitter version 3.0.3
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
